### PR TITLE
Avoid race condition in clearing TC interrupt flags

### DIFF
--- a/targets/hal/TARGET_Atmel/TARGET_SAM21/drivers/tc/tc_interrupt.c
+++ b/targets/hal/TARGET_Atmel/TARGET_SAM21/drivers/tc/tc_interrupt.c
@@ -114,35 +114,31 @@ void _tc_interrupt_handler(
                                          module->register_callback_mask &
                                          module->enable_callback_mask;
 
+    /* Clear all interrupt flags, before we start setting callbacks, which can take a long
+     * time during which the timer might trigger again. */
+    module->hw->COUNT8.INTFLAG.reg = interrupt_and_callback_status_mask;
+
     /* Check if an Overflow interrupt has occurred */
     if (interrupt_and_callback_status_mask & TC_INTFLAG_OVF) {
         /* Invoke registered and enabled callback function */
         (module->callback[TC_CALLBACK_OVERFLOW])(module);
-        /* Clear interrupt flag */
-        module->hw->COUNT8.INTFLAG.reg = TC_INTFLAG_OVF;
     }
 
     /* Check if an Error interrupt has occurred */
     if (interrupt_and_callback_status_mask & TC_INTFLAG_ERR) {
         /* Invoke registered and enabled callback function */
         (module->callback[TC_CALLBACK_ERROR])(module);
-        /* Clear interrupt flag */
-        module->hw->COUNT8.INTFLAG.reg = TC_INTFLAG_ERR;
     }
 
     /* Check if an Match/Capture Channel 0 interrupt has occurred */
     if (interrupt_and_callback_status_mask & TC_INTFLAG_MC(1)) {
         /* Invoke registered and enabled callback function */
         (module->callback[TC_CALLBACK_CC_CHANNEL0])(module);
-        /* Clear interrupt flag */
-        module->hw->COUNT8.INTFLAG.reg = TC_INTFLAG_MC(1);
     }
 
     /* Check if an Match/Capture Channel 1 interrupt has occurred */
     if (interrupt_and_callback_status_mask & TC_INTFLAG_MC(2)) {
         /* Invoke registered and enabled callback function */
         (module->callback[TC_CALLBACK_CC_CHANNEL1])(module);
-        /* Clear interrupt flag */
-        module->hw->COUNT8.INTFLAG.reg = TC_INTFLAG_MC(2);
     }
 }


### PR DESCRIPTION
There seems to be a race, when the module callback (which is processing the timed events) sets a new TC interrupt (to process the next timed event), and this interrupt triggers before the module callback finishes. The interrupt is then queued (i.e., is both pending and active), but the `_tc_interrupt_handler()` clears the flag in `INTFLAG`. Thus, the `_tc_interrupt_handler()` is invoked again, but `INTFLAG` is empty, and it does nothing. This means that processing of timed events stops completely.

It seems, this triggers particularly often if the priority of the TC interrupt is lowered.

CC @finneyj @jamesadevine 